### PR TITLE
Hdoan/fix remote url parser

### DIFF
--- a/git-pr-chain.py
+++ b/git-pr-chain.py
@@ -746,7 +746,7 @@ def cmd_new_pr(args):
     if head_commit.not_to_be_pushed:
         fatal(
             "There is a git-pr-chain: STOP commit upstream of this commit."
-            "  Please move it down before creating a git-pr-chain for it."
+            "  Please remove it before running `git-pr-chain new`."
         )
 
     maybe_pr_chain = head_commit.parse_pr_chain

--- a/git-pr-chain.py
+++ b/git-pr-chain.py
@@ -110,13 +110,16 @@ def gh_repo_client():
     # Translate our remote's URL into a github user/repo string.  (Is there
     # seriously not a beter way to do this?)
     remote_url = git("remote", "get-url", remote)
-    match = re.search(r"(?:[/:])([^/:]+/[^/:]+)(\.git)?$", remote_url)
+    match = re.search(r"(?:[/:])([^/:]+/[^/:]+)?$", remote_url)
     if not match:
         fatal(
             f"Couldn't extract github user/repo from {remote} "
             f"remote URL {remote_url}."
         )
     gh_repo_name = match.group(1)
+    # manually remove .git extension
+    if gh_repo_name.endswith(".git"):
+        gh_repo_name = gh_repo_name[:-4]
     return gh_client().get_repo(gh_repo_name)
 
 


### PR DESCRIPTION
Fix a bug introduced by the previous PR. 

Problem: The `(.git)?` makes the group optional and as a result of that, `.git` is included in the match repo_name.

Fix: For remote_url that contains `.git`, we need to remove it otherwise we cannot get the repo from Github. 

Only the last commit is relevant. This is based off #2 because I used git-pr-chain to create the commits locally.